### PR TITLE
Limit Poetry install in the development image to the main dependencies

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -22,7 +22,7 @@ COPY .. /opt/netbox_ninja_plugin
 RUN set -x \
     && poetry config virtualenvs.create false \
     && poetry config virtualenvs.in-project false \
-    && poetry install --no-ansi --no-interaction
+    && poetry install --only main --no-ansi --no-interaction
 
 WORKDIR /opt/netbox/netbox
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ autoflake = "^2.3.1"
 pre-commit = "^4.2.0"
 
 [tool.poetry.group.dev.dependencies]
-django = "5.1.8"
+django = "5.2.13"
 jinja2 = "3.1.6"
 django-taggit = "6.1.0"
 django-tables2 = "2.7.5"


### PR DESCRIPTION
Limit Poetry install in the development image to the main dependency group only.

This prevents plugin dev dependencies (including Django) from being installed into the NetBox runtime image, avoiding Django version conflicts with NetBox’s pinned stack.